### PR TITLE
Refactor router injections in components

### DIFF
--- a/src/app/componentes/HyF/footer/footer.component.spec.ts
+++ b/src/app/componentes/HyF/footer/footer.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { FooterComponent } from './footer.component';
 
@@ -8,7 +9,7 @@ describe('FooterComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FooterComponent]
+      imports: [FooterComponent, RouterTestingModule]
     })
     .compileComponents();
     

--- a/src/app/componentes/HyF/footer/footer.component.ts
+++ b/src/app/componentes/HyF/footer/footer.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 
 
@@ -11,10 +11,7 @@ import { Router, RouterLink } from '@angular/router';
 })
 export class FooterComponent {
 
-  private router: Router;
-  constructor(){
-    this.router = inject(Router)
-  }
+  constructor(private router: Router){}
   proyecto: string = 'Nenúfar';
   nombre: string = 'Pablo del Viso';
   universidad: string = 'Universidad Pontificia de Salamanca';

--- a/src/app/componentes/HyF/header/header.component.spec.ts
+++ b/src/app/componentes/HyF/header/header.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { HeaderComponent } from './header.component';
 
@@ -8,7 +9,7 @@ describe('HeaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HeaderComponent]
+      imports: [HeaderComponent, RouterTestingModule]
     })
     .compileComponents();
     

--- a/src/app/componentes/HyF/header/header.component.ts
+++ b/src/app/componentes/HyF/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 
 @Component({
@@ -10,10 +10,6 @@ import { Router, RouterLink } from '@angular/router';
 })
 export class HeaderComponent {
 
-  private router: Router;
-
-  constructor(router: Router) {
-    this.router = inject(Router);
-  }
+  constructor(private router: Router) {}
 
 }

--- a/src/app/componentes/principal/principal.component.spec.ts
+++ b/src/app/componentes/principal/principal.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { PrincipalComponent } from './principal.component';
 
@@ -8,7 +9,7 @@ describe('PrincipalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [PrincipalComponent]
+      imports: [PrincipalComponent, RouterTestingModule]
     })
     .compileComponents();
     

--- a/src/app/componentes/principal/principal.component.ts
+++ b/src/app/componentes/principal/principal.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { Router, RouterLink } from '@angular/router';
 
 @Component({
@@ -10,9 +10,6 @@ import { Router, RouterLink } from '@angular/router';
 })
 export class PrincipalComponent {
 
-  private router: Router;
-
-  constructor(router: Router) {
-    this.router = inject(Router);
+  constructor(private router: Router) {
   }
 }


### PR DESCRIPTION
## Summary
- use parameter property for `Router` injection in header, footer and principal components
- update corresponding tests to use `RouterTestingModule`

## Testing
- `npx ng test --watch=false` *(fails: `count-down-finished.guard.spec.ts` not found export, `AppComponent` property mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684321dae37c8325989dd7bbb5ffa960